### PR TITLE
Update actions/checkout to v6 in all workflows

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -51,7 +51,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
## Summary

GitHub Actions runners are emitting deprecation warnings: `actions/checkout@v3` (and `@v4` in pkgdown.yaml) run on Node.js 20, which will be forced to Node.js 24 on **June 16, 2026** and removed from runners on **September 16, 2026**.

This bumps every `actions/checkout` pin to **v6** (current release v6.0.3, Node.js 24) across `check-standard.yaml`, `test-coverage.yaml`, `pkgdown.yaml`, and `pr-commands.yaml` (×2).

Left as-is: `r-lib/actions@v2`, `r-hub/actions@v1`, and `JamesIves/github-pages-deploy-action@v4` — these are floating major tags whose maintainers track runner requirements (JamesIves v4 currently resolves to v4.8.0), and none appear in the deprecation warning.

The CI runs on this PR itself will exercise the updated checkout step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)