### PR TITLE
Exclude .claude directory from package builds

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,6 +19,7 @@
 ^revdep$
 ^CRAN-SUBMISSION$
 ^\.DS_Store$
+^\.claude$
 ^doc$
 ^Meta$
 ^vignettes/articles$

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ R/.DS_Store
 inst/doc
 /doc/
 /Meta/
+
+# Claude Code local settings
+.claude/


### PR DESCRIPTION
## Summary

`R CMD check` flags a hidden `.claude` directory in the package tarball:

```
N  checking for hidden files and directories ...
   Found the following hidden files and directories:
     .claude
```

This is Claude Code's local project-settings directory (`.claude/settings.local.json`), untracked by git but swept into the tarball by `R CMD build`.

## Changes
- `.Rbuildignore`: added `^\.claude$`
- `.gitignore`: added `.claude/` so local settings are never committed

## Verification
Rebuilt the tarball with `pkgbuild::build()` — zero `.claude` entries in `FedData_4.4.0.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)