### PR TITLE
Update cran-comments for the 4.4.0 submission

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,7 +6,7 @@ editor_options:
 
 # CRAN comments
 
-This is a minor release from FedData v4.2.0 to FedData v4.3.0. Please
+This is a minor release from FedData v4.3.0 to FedData v4.4.0. Please
 see NEWS.md for release details.
 
 ------------------------------------------------------------------------
@@ -15,7 +15,7 @@ see NEWS.md for release details.
 
 `devtools::check()` result:
 
-**Test environment:** aarch64-apple-darwin20 (64-bit), R 4.5.0 (2025-04-11)
+**Test environment:** aarch64-apple-darwin23 (64-bit), R 4.6.0 (2026-04-24)
 
 **0 errors ✔ \| 0 warnings ✔ \| 0 notes ✔**
 
@@ -26,7 +26,9 @@ see NEWS.md for release details.
 **Test environments:**
 
 -   macOS-latest, R release
+-   macOS-latest, R devel
 -   windows-latest, R release
+-   windows-latest, R devel
 -   ubuntu-latest, R devel
 -   ubuntu-latest, R release
 -   ubuntu-latest, R oldrel-1
@@ -35,21 +37,10 @@ see NEWS.md for release details.
 
 ------------------------------------------------------------------------
 
-## win-builder results
-
-`devtools::check_win_devel()` result:
-
-**Test environment:** Windows Server 2022 x64 (build 20348), R-devel, 64 bit
-
-**0 errors ✔ \| 0 warnings ✔ \| 0 notes ✖**
-
-------------------------------------------------------------------------
-
 ## revdepcheck results
 
-We checked 0 reverse dependencies, comparing R CMD check results 
+We checked 1 reverse dependency (wxgenR), comparing R CMD check results 
 across CRAN and dev versions of this package.
 
  * We saw 0 new problems
  * We failed to check 0 packages
-


### PR DESCRIPTION
## Summary

Prepares `cran-comments.md` for the 4.4.0 submission:

- Release line updated (4.3.0 → 4.4.0).
- **Local check** (run today, R 4.6.0 on aarch64-apple-darwin23): 0 errors / 0 warnings / 0 notes.
- **GitHub Actions** environment list updated to the new 7-job matrix, which now includes R-devel on Windows and macOS — the **win-builder section is removed**, since the matrix provides that coverage on every push (a final `devtools::check_win_devel()` before submission remains optional).
- **revdepcheck**: FedData now has one reverse dependency, [wxgenR](https://cran.r-project.org/package=wxgenR) (Suggests). Verified: it references FedData only in a data-provenance comment (no code calls — notably, nothing touches the deprecated `get_daymet()`), and `R CMD check` of wxgenR against the dev FedData passes (`Status: OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)